### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://mmitrik.visualstudio.com/f8577591-b917-4a56-94ea-6d8322a07aaa/26fc71cf-4ce1-4e38-99c9-7c15d3e27c4a/_apis/work/boardbadge/41df374c-5f11-432e-9f20-8ff58fe2cab6)](https://mmitrik.visualstudio.com/f8577591-b917-4a56-94ea-6d8322a07aaa/_boards/board/t/26fc71cf-4ce1-4e38-99c9-7c15d3e27c4a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://mmitrik.visualstudio.com/f8577591-b917-4a56-94ea-6d8322a07aaa/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.